### PR TITLE
Audit CLTokenInputView for nullability and Objective-C generics

### DIFF
--- a/CLTokenInputView/CLTokenInputView/CLBackspaceDetectingTextField.h
+++ b/CLTokenInputView/CLTokenInputView/CLBackspaceDetectingTextField.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CLBackspaceDetectingTextField;
 @protocol CLBackspaceDetectingTextFieldDelegate <UITextFieldDelegate>
 
@@ -27,6 +29,8 @@
  */
 @interface CLBackspaceDetectingTextField : UITextField <UIKeyInput>
 
-@property (weak, nonatomic) NSObject <CLBackspaceDetectingTextFieldDelegate> *delegate;
+@property (weak, nonatomic, nullable) NSObject <CLBackspaceDetectingTextFieldDelegate> *delegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CLTokenInputView/CLTokenInputView/CLToken.h
+++ b/CLTokenInputView/CLTokenInputView/CLToken.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This is a high level object that is provided to the
  * CLTokenInputView when tokens should be added/removed
@@ -17,9 +19,11 @@
 /** The text to display in the token view */
 @property (copy, nonatomic) NSString *displayText;
 /** Used for storing anything that would be useful later on */
-@property (strong, nonatomic) NSObject *context;
+@property (strong, nonatomic, nullable) NSObject *context;
 
 
-- (id)initWithDisplayText:(NSString *)displayText context:(NSObject *)context;
+- (id)initWithDisplayText:(NSString *)displayText context:(nullable NSObject *)context;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -10,6 +10,8 @@
 
 #import "CLToken.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CLTokenInputView;
 @protocol CLTokenInputViewDelegate <NSObject>
 
@@ -28,7 +30,7 @@
 /**
  * Called when the text field text has changed. You should update your autocompleting UI based on the text supplied.
  */
-- (void)tokenInputView:(CLTokenInputView *)view didChangeText:(NSString *)text;
+- (void)tokenInputView:(CLTokenInputView *)view didChangeText:(nullable NSString *)text;
 /**
  * Called when a token has been added. You should use this opportunity to update your local list of selected items.
  */
@@ -54,15 +56,15 @@
 
 @interface CLTokenInputView : UIView
 
-@property (weak, nonatomic) IBOutlet NSObject <CLTokenInputViewDelegate> *delegate;
+@property (weak, nonatomic, nullable) IBOutlet NSObject <CLTokenInputViewDelegate> *delegate;
 /** An optional view that shows up presumably on the first line */
-@property (strong, nonatomic) UIView *fieldView;
+@property (strong, nonatomic, nullable) UIView *fieldView;
 /** Option text which can be displayed before the first line (e.g. "To:") */
-@property (copy, nonatomic) IBInspectable NSString *fieldName;
+@property (copy, nonatomic, nullable) IBInspectable NSString *fieldName;
 /** Color of optional */
-@property (strong, nonatomic) IBInspectable UIColor *fieldColor;
-@property (copy, nonatomic) IBInspectable NSString *placeholderText;
-@property (strong, nonatomic) UIView *accessoryView;
+@property (strong, nonatomic, nullable) IBInspectable UIColor *fieldColor;
+@property (copy, nonatomic, nullable) IBInspectable NSString *placeholderText;
+@property (strong, nonatomic, nullable) UIView *accessoryView;
 @property (assign, nonatomic) IBInspectable UIKeyboardType keyboardType;
 @property (assign, nonatomic) IBInspectable UITextAutocapitalizationType autocapitalizationType;
 @property (assign, nonatomic) IBInspectable UITextAutocorrectionType autocorrectionType;
@@ -71,14 +73,16 @@
 @property (readonly, nonatomic) NSArray *allTokens;
 @property (readonly, nonatomic, getter = isEditing) BOOL editing;
 @property (readonly, nonatomic) CGFloat textFieldDisplayOffset;
-@property (readonly, nonatomic) NSString *text;
+@property (readonly, nonatomic, nullable) NSString *text;
 
 - (void)addToken:(CLToken *)token;
 - (void)removeToken:(CLToken *)token;
-- (CLToken *)tokenizeTextfieldText;
+- (nullable CLToken *)tokenizeTextfieldText;
 
 // Editing
 - (void)beginEditing;
 - (void)endEditing;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A CLToken for a match (typically the first item in the matching results),
  * or nil if the text shouldn't be accepted.
  */
-- (CLToken *)tokenInputView:(CLTokenInputView *)view tokenForText:(NSString *)text;
+- (nullable CLToken *)tokenInputView:(CLTokenInputView *)view tokenForText:(NSString *)text;
 /**
  * Called when the view has updated its own height. If you are
  * not using Autolayout, you should use this method to update the

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -10,6 +10,14 @@
 
 #import "CLToken.h"
 
+#if __has_feature(objc_generics)
+#define CL_GENERIC_ARRAY(type) NSArray<type>
+#define CL_GENERIC_MUTABLE_ARRAY(type) NSMutableArray<type>
+#else
+#define CL_GENERIC_ARRAY(type) NSArray
+#define CL_GENERIC_MUTABLE_ARRAY(type) NSMutableArray
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class CLTokenInputView;
@@ -70,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UITextAutocorrectionType autocorrectionType;
 @property (assign, nonatomic) IBInspectable BOOL drawBottomBorder;
 
-@property (readonly, nonatomic) NSArray<CLToken *> *allTokens;
+@property (readonly, nonatomic) CL_GENERIC_ARRAY(CLToken *) *allTokens;
 @property (readonly, nonatomic, getter = isEditing) BOOL editing;
 @property (readonly, nonatomic) CGFloat textFieldDisplayOffset;
 @property (readonly, nonatomic, nullable) NSString *text;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UITextAutocorrectionType autocorrectionType;
 @property (assign, nonatomic) IBInspectable BOOL drawBottomBorder;
 
-@property (readonly, nonatomic) NSArray *allTokens;
+@property (readonly, nonatomic) NSArray<CLToken *> *allTokens;
 @property (readonly, nonatomic, getter = isEditing) BOOL editing;
 @property (readonly, nonatomic) CGFloat textFieldDisplayOffset;
 @property (readonly, nonatomic, nullable) NSString *text;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -25,8 +25,8 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 @interface CLTokenInputView () <CLBackspaceDetectingTextFieldDelegate, CLTokenViewDelegate>
 
-@property (strong, nonatomic) NSMutableArray<CLToken *> *tokens;
-@property (strong, nonatomic) NSMutableArray<CLTokenView *> *tokenViews;
+@property (strong, nonatomic) CL_GENERIC_MUTABLE_ARRAY(CLToken *) *tokens;
+@property (strong, nonatomic) CL_GENERIC_MUTABLE_ARRAY(CLTokenView *) *tokenViews;
 @property (strong, nonatomic) CLBackspaceDetectingTextField *textField;
 @property (strong, nonatomic) UILabel *fieldLabel;
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -25,8 +25,8 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 @interface CLTokenInputView () <CLBackspaceDetectingTextFieldDelegate, CLTokenViewDelegate>
 
-@property (strong, nonatomic) NSMutableArray *tokens;
-@property (strong, nonatomic) NSMutableArray *tokenViews;
+@property (strong, nonatomic) NSMutableArray<CLToken *> *tokens;
+@property (strong, nonatomic) NSMutableArray<CLTokenView *> *tokenViews;
 @property (strong, nonatomic) CLBackspaceDetectingTextField *textField;
 @property (strong, nonatomic) UILabel *fieldLabel;
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.h
@@ -10,11 +10,13 @@
 
 #import "CLToken.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CLTokenView;
 @protocol CLTokenViewDelegate <NSObject>
 
 @required
-- (void)tokenViewDidRequestDelete:(CLTokenView *)tokenView replaceWithText:(NSString *)replacementText;
+- (void)tokenViewDidRequestDelete:(CLTokenView *)tokenView replaceWithText:(nullable NSString *)replacementText;
 - (void)tokenViewDidRequestSelection:(CLTokenView *)tokenView;
 
 @end
@@ -22,7 +24,7 @@
 
 @interface CLTokenView : UIView <UIKeyInput>
 
-@property (weak, nonatomic) NSObject <CLTokenViewDelegate> *delegate;
+@property (weak, nonatomic, nullable) NSObject <CLTokenViewDelegate> *delegate;
 @property (assign, nonatomic) BOOL selected;
 
 - (id)initWithToken:(CLToken *)token;
@@ -30,6 +32,8 @@
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated;
 
 // For iOS 6 compatibility, provide the setter tintColor
-- (void)setTintColor:(UIColor *)tintColor;
+- (void)setTintColor:(nullable UIColor *)tintColor;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Audits CLTokenInputView for nullability and Objective-C generics (if available) to provide better compatibility when used in a Swift codebase.