### PR TITLE
Carthage compatibility

### DIFF
--- a/CLTokenInput/CLTokenInput.h
+++ b/CLTokenInput/CLTokenInput.h
@@ -1,0 +1,21 @@
+//
+//  CLTokenInput.h
+//  CLTokenInput
+//
+//  Created by Engin Kurutepe on 21/10/15.
+//  Copyright © 2015 Cluster Labs, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for CLTokenInput.
+FOUNDATION_EXPORT double CLTokenInputVersionNumber;
+
+//! Project version string for CLTokenInput.
+FOUNDATION_EXPORT const unsigned char CLTokenInputVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <CLTokenInput/PublicHeader.h>
+#import <CLTokenInput/CLTokenInputView.h>
+#import <CLTokenInput/CLToken.h>
+#import <CLTokenInput/CLTokenView.h>
+#import <CLTokenInput/CLBackspaceDetectingTextField.h>

--- a/CLTokenInput/Info.plist
+++ b/CLTokenInput/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/CLTokenInputTests/CLTokenInputTests.m
+++ b/CLTokenInputTests/CLTokenInputTests.m
@@ -1,0 +1,39 @@
+//
+//  CLTokenInputTests.m
+//  CLTokenInputTests
+//
+//  Created by Engin Kurutepe on 21/10/15.
+//  Copyright © 2015 Cluster Labs, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface CLTokenInputTests : XCTestCase
+
+@end
+
+@implementation CLTokenInputTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/CLTokenInputTests/Info.plist
+++ b/CLTokenInputTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/CLTokenInputView.xcodeproj/project.pbxproj
+++ b/CLTokenInputView.xcodeproj/project.pbxproj
@@ -27,10 +27,10 @@
 		65B16BBF18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BBD18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m */; };
 		65B16BC318BC26C9003AA819 /* CLToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BC118BC26C9003AA819 /* CLToken.m */; };
 		87E394901BD8201400D41FD4 /* CLTokenInput.h in Headers */ = {isa = PBXBuildFile; fileRef = 87E3948F1BD8201400D41FD4 /* CLTokenInput.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		87E394971BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */; settings = {ASSET_TAGS = (); }; };
+		87E394971BD8201500D41FD4 /* CLTokenInputView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInputView.framework */; settings = {ASSET_TAGS = (); }; };
 		87E3949E1BD8201500D41FD4 /* CLTokenInputTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 87E3949D1BD8201500D41FD4 /* CLTokenInputTests.m */; };
-		87E394A21BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */; };
-		87E394A31BD8201500D41FD4 /* CLTokenInput.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		87E394A21BD8201500D41FD4 /* CLTokenInputView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInputView.framework */; };
+		87E394A31BD8201500D41FD4 /* CLTokenInputView.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInputView.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		87E394AB1BD8202500D41FD4 /* CLTokenInputView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BAE18BC17D2003AA819 /* CLTokenInputView.m */; };
 		87E394AC1BD8202500D41FD4 /* CLTokenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB218BC17EC003AA819 /* CLTokenView.m */; };
 		87E394AD1BD8202500D41FD4 /* CLBackspaceDetectingTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BBD18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m */; };
@@ -80,7 +80,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				87E394A31BD8201500D41FD4 /* CLTokenInput.framework in Embed Frameworks */,
+				87E394A31BD8201500D41FD4 /* CLTokenInputView.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -88,7 +88,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		65B16B7A18BC16F6003AA819 /* CLTokenInputView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CLTokenInputView.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		65B16B7A18BC16F6003AA819 /* CLTokenInputViewApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CLTokenInputViewApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		65B16B7D18BC16F6003AA819 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		65B16B7F18BC16F6003AA819 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		65B16B8118BC16F6003AA819 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -115,7 +115,7 @@
 		65B16BBD18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CLBackspaceDetectingTextField.m; path = CLTokenInputView/CLBackspaceDetectingTextField.m; sourceTree = "<group>"; };
 		65B16BC018BC26C9003AA819 /* CLToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CLToken.h; path = CLTokenInputView/CLToken.h; sourceTree = "<group>"; };
 		65B16BC118BC26C9003AA819 /* CLToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CLToken.m; path = CLTokenInputView/CLToken.m; sourceTree = "<group>"; };
-		87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CLTokenInput.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		87E3948D1BD8201400D41FD4 /* CLTokenInputView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CLTokenInputView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		87E3948F1BD8201400D41FD4 /* CLTokenInput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CLTokenInput.h; sourceTree = "<group>"; };
 		87E394911BD8201400D41FD4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		87E394961BD8201500D41FD4 /* CLTokenInputTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CLTokenInputTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -130,7 +130,7 @@
 			files = (
 				65B16B8018BC16F6003AA819 /* CoreGraphics.framework in Frameworks */,
 				65B16B8218BC16F6003AA819 /* UIKit.framework in Frameworks */,
-				87E394A21BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */,
+				87E394A21BD8201500D41FD4 /* CLTokenInputView.framework in Frameworks */,
 				65B16B7E18BC16F6003AA819 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -156,7 +156,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				87E394971BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */,
+				87E394971BD8201500D41FD4 /* CLTokenInputView.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,9 +178,9 @@
 		65B16B7B18BC16F6003AA819 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				65B16B7A18BC16F6003AA819 /* CLTokenInputView.app */,
+				65B16B7A18BC16F6003AA819 /* CLTokenInputViewApp.app */,
 				65B16B9518BC16F7003AA819 /* CLTokenInputViewTests.xctest */,
-				87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */,
+				87E3948D1BD8201400D41FD4 /* CLTokenInputView.framework */,
 				87E394961BD8201500D41FD4 /* CLTokenInputTests.xctest */,
 			);
 			name = Products;
@@ -292,9 +292,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		65B16B7918BC16F6003AA819 /* CLTokenInputView */ = {
+		65B16B7918BC16F6003AA819 /* CLTokenInputViewApp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 65B16BA618BC16F7003AA819 /* Build configuration list for PBXNativeTarget "CLTokenInputView" */;
+			buildConfigurationList = 65B16BA618BC16F7003AA819 /* Build configuration list for PBXNativeTarget "CLTokenInputViewApp" */;
 			buildPhases = (
 				65B16B7618BC16F6003AA819 /* Sources */,
 				65B16B7718BC16F6003AA819 /* Frameworks */,
@@ -306,9 +306,9 @@
 			dependencies = (
 				87E394A11BD8201500D41FD4 /* PBXTargetDependency */,
 			);
-			name = CLTokenInputView;
+			name = CLTokenInputViewApp;
 			productName = CLTokenInputView;
-			productReference = 65B16B7A18BC16F6003AA819 /* CLTokenInputView.app */;
+			productReference = 65B16B7A18BC16F6003AA819 /* CLTokenInputViewApp.app */;
 			productType = "com.apple.product-type.application";
 		};
 		65B16B9418BC16F7003AA819 /* CLTokenInputViewTests */ = {
@@ -329,9 +329,9 @@
 			productReference = 65B16B9518BC16F7003AA819 /* CLTokenInputViewTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		87E3948C1BD8201400D41FD4 /* CLTokenInput */ = {
+		87E3948C1BD8201400D41FD4 /* CLTokenInputView */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 87E394A81BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInput" */;
+			buildConfigurationList = 87E394A81BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInputView" */;
 			buildPhases = (
 				87E394881BD8201400D41FD4 /* Sources */,
 				87E394891BD8201400D41FD4 /* Frameworks */,
@@ -342,9 +342,9 @@
 			);
 			dependencies = (
 			);
-			name = CLTokenInput;
+			name = CLTokenInputView;
 			productName = CLTokenInput;
-			productReference = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */;
+			productReference = 87E3948D1BD8201400D41FD4 /* CLTokenInputView.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		87E394951BD8201500D41FD4 /* CLTokenInputTests */ = {
@@ -400,9 +400,9 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				65B16B7918BC16F6003AA819 /* CLTokenInputView */,
+				65B16B7918BC16F6003AA819 /* CLTokenInputViewApp */,
 				65B16B9418BC16F7003AA819 /* CLTokenInputViewTests */,
-				87E3948C1BD8201400D41FD4 /* CLTokenInput */,
+				87E3948C1BD8201400D41FD4 /* CLTokenInputView */,
 				87E394951BD8201500D41FD4 /* CLTokenInputTests */,
 			);
 		};
@@ -492,22 +492,22 @@
 /* Begin PBXTargetDependency section */
 		65B16B9B18BC16F7003AA819 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 65B16B7918BC16F6003AA819 /* CLTokenInputView */;
+			target = 65B16B7918BC16F6003AA819 /* CLTokenInputViewApp */;
 			targetProxy = 65B16B9A18BC16F7003AA819 /* PBXContainerItemProxy */;
 		};
 		87E394991BD8201500D41FD4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 87E3948C1BD8201400D41FD4 /* CLTokenInput */;
+			target = 87E3948C1BD8201400D41FD4 /* CLTokenInputView */;
 			targetProxy = 87E394981BD8201500D41FD4 /* PBXContainerItemProxy */;
 		};
 		87E3949B1BD8201500D41FD4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 65B16B7918BC16F6003AA819 /* CLTokenInputView */;
+			target = 65B16B7918BC16F6003AA819 /* CLTokenInputViewApp */;
 			targetProxy = 87E3949A1BD8201500D41FD4 /* PBXContainerItemProxy */;
 		};
 		87E394A11BD8201500D41FD4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 87E3948C1BD8201400D41FD4 /* CLTokenInput */;
+			target = 87E3948C1BD8201400D41FD4 /* CLTokenInputView */;
 			targetProxy = 87E394A01BD8201500D41FD4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -781,7 +781,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		65B16BA618BC16F7003AA819 /* Build configuration list for PBXNativeTarget "CLTokenInputView" */ = {
+		65B16BA618BC16F7003AA819 /* Build configuration list for PBXNativeTarget "CLTokenInputViewApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				65B16BA718BC16F7003AA819 /* Debug */,
@@ -799,7 +799,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		87E394A81BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInput" */ = {
+		87E394A81BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInputView" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				87E394A41BD8201500D41FD4 /* Debug */,

--- a/CLTokenInputView.xcodeproj/project.pbxproj
+++ b/CLTokenInputView.xcodeproj/project.pbxproj
@@ -19,18 +19,27 @@
 		65B16B9918BC16F7003AA819 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65B16B8118BC16F6003AA819 /* UIKit.framework */; };
 		65B16BA118BC16F7003AA819 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 65B16B9F18BC16F7003AA819 /* InfoPlist.strings */; };
 		65B16BA318BC16F7003AA819 /* CLTokenInputViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BA218BC16F7003AA819 /* CLTokenInputViewTests.m */; };
-		65B16BAF18BC17D2003AA819 /* CLTokenInputView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BAE18BC17D2003AA819 /* CLTokenInputView.m */; };
 		65B16BB018BC17D2003AA819 /* CLTokenInputView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BAE18BC17D2003AA819 /* CLTokenInputView.m */; };
-		65B16BB318BC17EC003AA819 /* CLTokenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB218BC17EC003AA819 /* CLTokenView.m */; };
 		65B16BB418BC17EC003AA819 /* CLTokenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB218BC17EC003AA819 /* CLTokenView.m */; };
-		65B16BB818BC1826003AA819 /* CLTokenInputViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB618BC1826003AA819 /* CLTokenInputViewController.m */; };
 		65B16BB918BC1826003AA819 /* CLTokenInputViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB618BC1826003AA819 /* CLTokenInputViewController.m */; };
 		65B16BBA18BC1826003AA819 /* CLTokenInputViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65B16BB718BC1826003AA819 /* CLTokenInputViewController.xib */; };
 		65B16BBB18BC1826003AA819 /* CLTokenInputViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65B16BB718BC1826003AA819 /* CLTokenInputViewController.xib */; };
-		65B16BBE18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BBD18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m */; };
 		65B16BBF18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BBD18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m */; };
-		65B16BC218BC26C9003AA819 /* CLToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BC118BC26C9003AA819 /* CLToken.m */; };
 		65B16BC318BC26C9003AA819 /* CLToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BC118BC26C9003AA819 /* CLToken.m */; };
+		87E394901BD8201400D41FD4 /* CLTokenInput.h in Headers */ = {isa = PBXBuildFile; fileRef = 87E3948F1BD8201400D41FD4 /* CLTokenInput.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87E394971BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */; settings = {ASSET_TAGS = (); }; };
+		87E3949E1BD8201500D41FD4 /* CLTokenInputTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 87E3949D1BD8201500D41FD4 /* CLTokenInputTests.m */; };
+		87E394A21BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */; };
+		87E394A31BD8201500D41FD4 /* CLTokenInput.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		87E394AB1BD8202500D41FD4 /* CLTokenInputView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BAE18BC17D2003AA819 /* CLTokenInputView.m */; };
+		87E394AC1BD8202500D41FD4 /* CLTokenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB218BC17EC003AA819 /* CLTokenView.m */; };
+		87E394AD1BD8202500D41FD4 /* CLBackspaceDetectingTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BBD18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m */; };
+		87E394AE1BD8202500D41FD4 /* CLToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BC118BC26C9003AA819 /* CLToken.m */; };
+		87E394AF1BD8203300D41FD4 /* CLTokenInputView.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BAD18BC17D2003AA819 /* CLTokenInputView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87E394B01BD8203300D41FD4 /* CLTokenView.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BB118BC17EC003AA819 /* CLTokenView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87E394B11BD8203300D41FD4 /* CLBackspaceDetectingTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BBC18BC1D9E003AA819 /* CLBackspaceDetectingTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87E394B21BD8203300D41FD4 /* CLToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BC018BC26C9003AA819 /* CLToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87E394B31BD8212800D41FD4 /* CLTokenInputViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB618BC1826003AA819 /* CLTokenInputViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,7 +50,42 @@
 			remoteGlobalIDString = 65B16B7918BC16F6003AA819;
 			remoteInfo = CLTokenInputView;
 		};
+		87E394981BD8201500D41FD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65B16B7218BC16F6003AA819 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 87E3948C1BD8201400D41FD4;
+			remoteInfo = CLTokenInput;
+		};
+		87E3949A1BD8201500D41FD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65B16B7218BC16F6003AA819 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65B16B7918BC16F6003AA819;
+			remoteInfo = CLTokenInputView;
+		};
+		87E394A01BD8201500D41FD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65B16B7218BC16F6003AA819 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 87E3948C1BD8201400D41FD4;
+			remoteInfo = CLTokenInput;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		87E394A91BD8201500D41FD4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				87E394A31BD8201500D41FD4 /* CLTokenInput.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		65B16B7A18BC16F6003AA819 /* CLTokenInputView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CLTokenInputView.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -71,6 +115,12 @@
 		65B16BBD18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CLBackspaceDetectingTextField.m; path = CLTokenInputView/CLBackspaceDetectingTextField.m; sourceTree = "<group>"; };
 		65B16BC018BC26C9003AA819 /* CLToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CLToken.h; path = CLTokenInputView/CLToken.h; sourceTree = "<group>"; };
 		65B16BC118BC26C9003AA819 /* CLToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CLToken.m; path = CLTokenInputView/CLToken.m; sourceTree = "<group>"; };
+		87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CLTokenInput.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		87E3948F1BD8201400D41FD4 /* CLTokenInput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CLTokenInput.h; sourceTree = "<group>"; };
+		87E394911BD8201400D41FD4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		87E394961BD8201500D41FD4 /* CLTokenInputTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CLTokenInputTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		87E3949D1BD8201500D41FD4 /* CLTokenInputTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CLTokenInputTests.m; sourceTree = "<group>"; };
+		87E3949F1BD8201500D41FD4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +130,7 @@
 			files = (
 				65B16B8018BC16F6003AA819 /* CoreGraphics.framework in Frameworks */,
 				65B16B8218BC16F6003AA819 /* UIKit.framework in Frameworks */,
+				87E394A21BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */,
 				65B16B7E18BC16F6003AA819 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -94,6 +145,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		87E394891BD8201400D41FD4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		87E394931BD8201500D41FD4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				87E394971BD8201500D41FD4 /* CLTokenInput.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -102,6 +168,8 @@
 			children = (
 				65B16B8318BC16F6003AA819 /* CLTokenInputView */,
 				65B16B9C18BC16F7003AA819 /* CLTokenInputViewTests */,
+				87E3948E1BD8201400D41FD4 /* CLTokenInput */,
+				87E3949C1BD8201500D41FD4 /* CLTokenInputTests */,
 				65B16B7C18BC16F6003AA819 /* Frameworks */,
 				65B16B7B18BC16F6003AA819 /* Products */,
 			);
@@ -112,6 +180,8 @@
 			children = (
 				65B16B7A18BC16F6003AA819 /* CLTokenInputView.app */,
 				65B16B9518BC16F7003AA819 /* CLTokenInputViewTests.xctest */,
+				87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */,
+				87E394961BD8201500D41FD4 /* CLTokenInputTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -130,7 +200,6 @@
 		65B16B8318BC16F6003AA819 /* CLTokenInputView */ = {
 			isa = PBXGroup;
 			children = (
-				65B16BAC18BC17A5003AA819 /* CLTokenInputView */,
 				65B16B8C18BC16F6003AA819 /* CLAppDelegate.h */,
 				65B16B8D18BC16F6003AA819 /* CLAppDelegate.m */,
 				65B16BB518BC1826003AA819 /* CLTokenInputViewController.h */,
@@ -183,10 +252,44 @@
 				65B16BC018BC26C9003AA819 /* CLToken.h */,
 				65B16BC118BC26C9003AA819 /* CLToken.m */,
 			);
-			name = CLTokenInputView;
+			path = CLTokenInputView;
+			sourceTree = SOURCE_ROOT;
+		};
+		87E3948E1BD8201400D41FD4 /* CLTokenInput */ = {
+			isa = PBXGroup;
+			children = (
+				65B16BAC18BC17A5003AA819 /* CLTokenInputView */,
+				87E3948F1BD8201400D41FD4 /* CLTokenInput.h */,
+				87E394911BD8201400D41FD4 /* Info.plist */,
+			);
+			path = CLTokenInput;
+			sourceTree = "<group>";
+		};
+		87E3949C1BD8201500D41FD4 /* CLTokenInputTests */ = {
+			isa = PBXGroup;
+			children = (
+				87E3949D1BD8201500D41FD4 /* CLTokenInputTests.m */,
+				87E3949F1BD8201500D41FD4 /* Info.plist */,
+			);
+			path = CLTokenInputTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		87E3948A1BD8201400D41FD4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				87E394AF1BD8203300D41FD4 /* CLTokenInputView.h in Headers */,
+				87E394B01BD8203300D41FD4 /* CLTokenView.h in Headers */,
+				87E394B11BD8203300D41FD4 /* CLBackspaceDetectingTextField.h in Headers */,
+				87E394B21BD8203300D41FD4 /* CLToken.h in Headers */,
+				87E394901BD8201400D41FD4 /* CLTokenInput.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		65B16B7918BC16F6003AA819 /* CLTokenInputView */ = {
@@ -196,10 +299,12 @@
 				65B16B7618BC16F6003AA819 /* Sources */,
 				65B16B7718BC16F6003AA819 /* Frameworks */,
 				65B16B7818BC16F6003AA819 /* Resources */,
+				87E394A91BD8201500D41FD4 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				87E394A11BD8201500D41FD4 /* PBXTargetDependency */,
 			);
 			name = CLTokenInputView;
 			productName = CLTokenInputView;
@@ -224,6 +329,43 @@
 			productReference = 65B16B9518BC16F7003AA819 /* CLTokenInputViewTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		87E3948C1BD8201400D41FD4 /* CLTokenInput */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 87E394A81BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInput" */;
+			buildPhases = (
+				87E394881BD8201400D41FD4 /* Sources */,
+				87E394891BD8201400D41FD4 /* Frameworks */,
+				87E3948A1BD8201400D41FD4 /* Headers */,
+				87E3948B1BD8201400D41FD4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CLTokenInput;
+			productName = CLTokenInput;
+			productReference = 87E3948D1BD8201400D41FD4 /* CLTokenInput.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		87E394951BD8201500D41FD4 /* CLTokenInputTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 87E394AA1BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInputTests" */;
+			buildPhases = (
+				87E394921BD8201500D41FD4 /* Sources */,
+				87E394931BD8201500D41FD4 /* Frameworks */,
+				87E394941BD8201500D41FD4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				87E394991BD8201500D41FD4 /* PBXTargetDependency */,
+				87E3949B1BD8201500D41FD4 /* PBXTargetDependency */,
+			);
+			name = CLTokenInputTests;
+			productName = CLTokenInputTests;
+			productReference = 87E394961BD8201500D41FD4 /* CLTokenInputTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -235,6 +377,13 @@
 				ORGANIZATIONNAME = "Cluster Labs, Inc.";
 				TargetAttributes = {
 					65B16B9418BC16F7003AA819 = {
+						TestTargetID = 65B16B7918BC16F6003AA819;
+					};
+					87E3948C1BD8201400D41FD4 = {
+						CreatedOnToolsVersion = 7.0.1;
+					};
+					87E394951BD8201500D41FD4 = {
+						CreatedOnToolsVersion = 7.0.1;
 						TestTargetID = 65B16B7918BC16F6003AA819;
 					};
 				};
@@ -253,6 +402,8 @@
 			targets = (
 				65B16B7918BC16F6003AA819 /* CLTokenInputView */,
 				65B16B9418BC16F7003AA819 /* CLTokenInputViewTests */,
+				87E3948C1BD8201400D41FD4 /* CLTokenInput */,
+				87E394951BD8201500D41FD4 /* CLTokenInputTests */,
 			);
 		};
 /* End PBXProject section */
@@ -277,6 +428,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		87E3948B1BD8201400D41FD4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		87E394941BD8201500D41FD4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -284,13 +449,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65B16BBE18BC1D9E003AA819 /* CLBackspaceDetectingTextField.m in Sources */,
-				65B16BAF18BC17D2003AA819 /* CLTokenInputView.m in Sources */,
-				65B16BB818BC1826003AA819 /* CLTokenInputViewController.m in Sources */,
 				65B16B8A18BC16F6003AA819 /* main.m in Sources */,
 				65B16B8E18BC16F6003AA819 /* CLAppDelegate.m in Sources */,
-				65B16BB318BC17EC003AA819 /* CLTokenView.m in Sources */,
-				65B16BC218BC26C9003AA819 /* CLToken.m in Sources */,
+				87E394B31BD8212800D41FD4 /* CLTokenInputViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,6 +468,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		87E394881BD8201400D41FD4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				87E394AB1BD8202500D41FD4 /* CLTokenInputView.m in Sources */,
+				87E394AC1BD8202500D41FD4 /* CLTokenView.m in Sources */,
+				87E394AD1BD8202500D41FD4 /* CLBackspaceDetectingTextField.m in Sources */,
+				87E394AE1BD8202500D41FD4 /* CLToken.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		87E394921BD8201500D41FD4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				87E3949E1BD8201500D41FD4 /* CLTokenInputTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -314,6 +494,21 @@
 			isa = PBXTargetDependency;
 			target = 65B16B7918BC16F6003AA819 /* CLTokenInputView */;
 			targetProxy = 65B16B9A18BC16F7003AA819 /* PBXContainerItemProxy */;
+		};
+		87E394991BD8201500D41FD4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 87E3948C1BD8201400D41FD4 /* CLTokenInput */;
+			targetProxy = 87E394981BD8201500D41FD4 /* PBXContainerItemProxy */;
+		};
+		87E3949B1BD8201500D41FD4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65B16B7918BC16F6003AA819 /* CLTokenInputView */;
+			targetProxy = 87E3949A1BD8201500D41FD4 /* PBXContainerItemProxy */;
+		};
+		87E394A11BD8201500D41FD4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 87E3948C1BD8201400D41FD4 /* CLTokenInput */;
+			targetProxy = 87E394A01BD8201500D41FD4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -370,7 +565,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -402,7 +597,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -416,7 +611,8 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CLTokenInputView/CLTokenInputView-Prefix.pch";
 				INFOPLIST_FILE = "CLTokenInputView/CLTokenInputView-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getcluster.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -431,7 +627,8 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CLTokenInputView/CLTokenInputView-Prefix.pch";
 				INFOPLIST_FILE = "CLTokenInputView/CLTokenInputView-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getcluster.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -480,6 +677,98 @@
 			};
 			name = Release;
 		};
+		87E394A41BD8201500D41FD4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = CLTokenInput/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fifteenjugglers.CLTokenInput;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		87E394A51BD8201500D41FD4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = CLTokenInput/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fifteenjugglers.CLTokenInput;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		87E394A61BD8201500D41FD4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = CLTokenInputTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fifteenjugglers.CLTokenInputTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CLTokenInputView.app/CLTokenInputView";
+			};
+			name = Debug;
+		};
+		87E394A71BD8201500D41FD4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = CLTokenInputTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fifteenjugglers.CLTokenInputTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CLTokenInputView.app/CLTokenInputView";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -509,6 +798,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		87E394A81BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInput" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				87E394A41BD8201500D41FD4 /* Debug */,
+				87E394A51BD8201500D41FD4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		87E394AA1BD8201500D41FD4 /* Build configuration list for PBXNativeTarget "CLTokenInputTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				87E394A61BD8201500D41FD4 /* Debug */,
+				87E394A71BD8201500D41FD4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/CLTokenInputView.xcodeproj/xcshareddata/xcschemes/CLTokenInputView.xcscheme
+++ b/CLTokenInputView.xcodeproj/xcshareddata/xcschemes/CLTokenInputView.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "65B16B7918BC16F6003AA819"
+               BuildableName = "CLTokenInputView.app"
+               BlueprintName = "CLTokenInputView"
+               ReferencedContainer = "container:CLTokenInputView.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "65B16B9418BC16F7003AA819"
+               BuildableName = "CLTokenInputViewTests.xctest"
+               BlueprintName = "CLTokenInputViewTests"
+               ReferencedContainer = "container:CLTokenInputView.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "87E394951BD8201500D41FD4"
+               BuildableName = "CLTokenInputTests.xctest"
+               BlueprintName = "CLTokenInputTests"
+               ReferencedContainer = "container:CLTokenInputView.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65B16B7918BC16F6003AA819"
+            BuildableName = "CLTokenInputView.app"
+            BlueprintName = "CLTokenInputView"
+            ReferencedContainer = "container:CLTokenInputView.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65B16B7918BC16F6003AA819"
+            BuildableName = "CLTokenInputView.app"
+            BlueprintName = "CLTokenInputView"
+            ReferencedContainer = "container:CLTokenInputView.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65B16B7918BC16F6003AA819"
+            BuildableName = "CLTokenInputView.app"
+            BlueprintName = "CLTokenInputView"
+            ReferencedContainer = "container:CLTokenInputView.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CLTokenInputView.xcodeproj/xcshareddata/xcschemes/CLTokenInputView.xcscheme
+++ b/CLTokenInputView.xcodeproj/xcshareddata/xcschemes/CLTokenInputView.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,8 +14,8 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65B16B7918BC16F6003AA819"
-               BuildableName = "CLTokenInputView.app"
+               BlueprintIdentifier = "87E3948C1BD8201400D41FD4"
+               BuildableName = "CLTokenInputView.framework"
                BlueprintName = "CLTokenInputView"
                ReferencedContainer = "container:CLTokenInputView.xcodeproj">
             </BuildableReference>
@@ -28,36 +28,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65B16B9418BC16F7003AA819"
-               BuildableName = "CLTokenInputViewTests.xctest"
-               BlueprintName = "CLTokenInputViewTests"
-               ReferencedContainer = "container:CLTokenInputView.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "87E394951BD8201500D41FD4"
-               BuildableName = "CLTokenInputTests.xctest"
-               BlueprintName = "CLTokenInputTests"
-               ReferencedContainer = "container:CLTokenInputView.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65B16B7918BC16F6003AA819"
-            BuildableName = "CLTokenInputView.app"
-            BlueprintName = "CLTokenInputView"
-            ReferencedContainer = "container:CLTokenInputView.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -71,16 +42,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65B16B7918BC16F6003AA819"
-            BuildableName = "CLTokenInputView.app"
+            BlueprintIdentifier = "87E3948C1BD8201400D41FD4"
+            BuildableName = "CLTokenInputView.framework"
             BlueprintName = "CLTokenInputView"
             ReferencedContainer = "container:CLTokenInputView.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -90,16 +60,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65B16B7918BC16F6003AA819"
-            BuildableName = "CLTokenInputView.app"
+            BlueprintIdentifier = "87E3948C1BD8201400D41FD4"
+            BuildableName = "CLTokenInputView.framework"
             BlueprintName = "CLTokenInputView"
             ReferencedContainer = "container:CLTokenInputView.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/CLTokenInputView/CLTokenInputViewController.xib
+++ b/CLTokenInputView/CLTokenInputViewController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CLTokenInputViewController">
@@ -21,6 +21,7 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FM2-Aw-6xi" customClass="CLTokenInputView">
                     <rect key="frame" x="0.0" y="64" width="320" height="44"/>
+                    <animations/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" placeholder="YES" id="FVg-4h-VEC"/>
@@ -31,6 +32,7 @@
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yVy-7A-UfW" customClass="CLTokenInputView">
                     <rect key="frame" x="0.0" y="108" width="320" height="44"/>
+                    <animations/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" placeholder="YES" id="Xb8-c7-lvt"/>
@@ -41,6 +43,7 @@
                 </view>
                 <tableView hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="ngG-oE-HZd">
                     <rect key="frame" x="0.0" y="108" width="320" height="372"/>
+                    <animations/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="yp9-JH-5rL"/>
@@ -48,6 +51,7 @@
                     </connections>
                 </tableView>
             </subviews>
+            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="ngG-oE-HZd" firstAttribute="top" secondItem="FM2-Aw-6xi" secondAttribute="bottom" id="1kw-0b-caj"/>
@@ -65,9 +69,4 @@
             <simulatedScreenMetrics key="simulatedDestinationMetrics"/>
         </view>
     </objects>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/CLTokenInputView/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/CLTokenInputView/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,13 +7,28 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
     },
     {
       "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
     }
   ],
   "info" : {


### PR DESCRIPTION
Moved the CLTokenInputView related classes out to a framework and added a shared framework scheme such that Carthage can automatically build the framework.
