### PR TITLE
Make text property readwrite.

### DIFF
--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -89,11 +89,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (copy, nonatomic) CL_GENERIC_SET(NSString *) *tokenizationCharacters;
 @property (assign, nonatomic) IBInspectable BOOL drawBottomBorder;
+@property (copy, nonatomic, nullable) NSString *text;
 
 @property (readonly, nonatomic) CL_GENERIC_ARRAY(CLToken *) *allTokens;
 @property (readonly, nonatomic, getter = isEditing) BOOL editing;
 @property (readonly, nonatomic) CGFloat textFieldDisplayOffset;
-@property (readonly, nonatomic, nullable) NSString *text;
 
 - (void)addToken:(CLToken *)token;
 - (void)removeToken:(CLToken *)token;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -397,6 +397,11 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 #pragma mark - Textfield text
 
 
+- (void)setText:(NSString *)text
+{
+    self.textField.text = [text copy];
+}
+
 - (NSString *)text
 {
     return self.textField.text;


### PR DESCRIPTION
Makes it possible to set the `text` property.

My use case for this is that I would like to be able clear any entered text after programmatically removing a token.
