### PR TITLE
Fix typo in comment

### DIFF
--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -243,7 +243,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
         }
 
         tokenRect.origin.x = curX;
-        // Center our tokenView vertially within STANDARD_ROW_HEIGHT
+        // Center our tokenView vertically within STANDARD_ROW_HEIGHT
         tokenRect.origin.y = curY + ((STANDARD_ROW_HEIGHT-CGRectGetHeight(tokenRect))/2.0);
         tokenView.frame = tokenRect;
 


### PR DESCRIPTION
I was looking through the code, and fixed the typo from 'vertially' to 'vertically'.