### PR TITLE
Added support for coloring each token

### DIFF
--- a/CLTokenInputView.podspec
+++ b/CLTokenInputView.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "CLTokenInputView"
-  s.version      = "2.4.0"
+  s.version      = "2.4.1"
   s.summary      = "A replica of iOS's native contact bubbles UI."
 
   s.description  = <<-DESC
@@ -71,7 +71,7 @@ Pod::Spec.new do |s|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "9.0"
 
   #  When using multiple platforms
   # s.ios.deployment_target = "5.0"

--- a/CLTokenInputView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CLTokenInputView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CLTokenInputView/CLTokenInputView/CLToken.h
+++ b/CLTokenInputView/CLTokenInputView/CLToken.h
@@ -18,6 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** The text to display in the token view */
 @property (copy, nonatomic) NSString *displayText;
+
+/** The custom tint color for this token */
+@property (nonatomic, nullable) UIColor *color;
+
 /** Used for storing anything that would be useful later on */
 @property (strong, nonatomic, nullable) NSObject *context;
 

--- a/CLTokenInputView/CLTokenInputView/CLToken.m
+++ b/CLTokenInputView/CLTokenInputView/CLToken.m
@@ -39,7 +39,7 @@
 
 - (NSUInteger)hash
 {
-    return self.displayText.hash + self.context.hash;
+    return self.displayText.hash + self.color.hash + self.context.hash;
 }
 
 @end

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -116,7 +116,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     [self.tokens addObject:token];
     CLTokenView *tokenView = [[CLTokenView alloc] initWithToken:token font:self.textField.font];
     if ([self respondsToSelector:@selector(tintColor)]) {
-        tokenView.tintColor = self.tintColor;
+        tokenView.tintColor = token.color ?: self.tintColor;
     }
     tokenView.delegate = self;
     CGSize intrinsicSize = tokenView.intrinsicContentSize;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -104,8 +104,10 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 - (void)tintColorDidChange
 {
-    for (UIView *tokenView in self.tokenViews) {
-        tokenView.tintColor = self.tintColor;
+    for (CLTokenView *tokenView in self.tokenViews) {
+		if (!tokenView.overridesTintColor) {
+			tokenView.tintColor = self.tintColor;
+		}
     }
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -93,6 +93,11 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     return CGSizeMake(UIViewNoIntrinsicMetric, MAX(45, self.intrinsicContentHeight));
 }
 
+#pragma mark - Allow becoming first responder
+
+- (BOOL)becomeFirstResponder {
+	return [self.textField becomeFirstResponder];
+}
 
 #pragma mark - Tint color
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic, nullable) NSObject <CLTokenViewDelegate> *delegate;
 @property (assign, nonatomic) BOOL selected;
 @property (assign, nonatomic) BOOL hideUnselectedComma;
+@property (assign, nonatomic) BOOL overridesTintColor;
 
 - (id)initWithToken:(CLToken *)token font:(nullable UIFont *)font;
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.m
@@ -35,7 +35,8 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
 {
     self = [super initWithFrame:CGRectZero];
     if (self) {
-        UIColor *tintColor = [UIColor colorWithRed:0.0823 green:0.4941 blue:0.9843 alpha:1.0];
+		self.overridesTintColor = (token.color != nil);
+		UIColor *tintColor = token.color ?: [UIColor colorWithRed:0.0823 green:0.4941 blue:0.9843 alpha:1.0];
         if ([self respondsToSelector:@selector(tintColor)]) {
             tintColor = self.tintColor;
         }


### PR DESCRIPTION
Modified `CLToken` to be able to accept a `color` property and then updated `CLTokenInputView` to use the property, if it has been set.

In addition, I have updated the example to demonstrate using the "color" property
