### PR TITLE
Expose textField and fieldLabel to be styled

### DIFF
--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "CLBackspaceDetectingTextField.h"
 #import "CLToken.h"
 
 #if __has_feature(objc_generics)
@@ -86,6 +87,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UITextAutocapitalizationType autocapitalizationType;
 @property (assign, nonatomic) IBInspectable UITextAutocorrectionType autocorrectionType;
 @property (assign, nonatomic) IBInspectable UIKeyboardAppearance keyboardAppearance;
+
+@property (strong, nonatomic) CLBackspaceDetectingTextField *textField;
+@property (strong, nonatomic) UILabel *fieldLabel;
+
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -8,7 +8,6 @@
 
 #import "CLTokenInputView.h"
 
-#import "CLBackspaceDetectingTextField.h"
 #import "CLTokenView.h"
 
 static CGFloat const HSPACE = 0.0;
@@ -27,8 +26,6 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 @property (strong, nonatomic) CL_GENERIC_MUTABLE_ARRAY(CLToken *) *tokens;
 @property (strong, nonatomic) CL_GENERIC_MUTABLE_ARRAY(CLTokenView *) *tokenViews;
-@property (strong, nonatomic) CLBackspaceDetectingTextField *textField;
-@property (strong, nonatomic) UILabel *fieldLabel;
 
 
 @property (assign, nonatomic) CGFloat intrinsicContentHeight;


### PR DESCRIPTION
In order to properly style the textField and fieldLabel, they need to be public properties.
