### PR TITLE
Fix issue where tapping backspace to delete a single letter also selects the previous token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,72 @@
-# Xcode
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos,synology,xcode,swiftpackagemanager,cocoapods
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,synology,xcode,swiftpackagemanager,cocoapods
+
+### CocoaPods ###
+## CocoaPods GitIgnore Template
+
+# CocoaPods - Only use to conserve bandwidth / Save time on Pushing
+#           - Also handy if you have a large number of dependant pods
+#           - AS PER https://guides.cocoapods.org/using/using-cocoapods.html NEVER IGNORE THE LOCK FILE
+Pods/
+
+### macOS ###
+# General
 .DS_Store
-build/
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-*.xccheckout
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### SwiftPackageManager ###
+Packages
+.build/
 xcuserdata
-profile
-*.moved-aside
-DerivedData
-.idea/
+DerivedData/
+*.xcodeproj
+
+
+### Synology ###
+# Thumbnails
+@eaDir
+# Recycle bin
+\#recycle
+
+### Xcode ###
+## User settings
+xcuserdata/
+
+## Xcode 8 and earlier
+*.xcscmblueprint
+*.xccheckout
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,synology,xcode,swiftpackagemanager,cocoapods

--- a/CLTokenInputView/CLTokenInputView/CLBackspaceDetectingTextField.m
+++ b/CLTokenInputView/CLTokenInputView/CLBackspaceDetectingTextField.m
@@ -46,10 +46,6 @@
         }
     }
 
-    if (![textField.text length] && [[[UIDevice currentDevice] systemVersion] intValue] >= 8) {
-        [self deleteBackward];
-    }
-
     return shouldDelete;
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -307,18 +307,13 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 - (void)textFieldDidDeleteBackwards:(UITextField *)textField
 {
-    // Delay selecting the next token slightly, so that on iOS 8
-    // the deleteBackward on CLTokenView is not called immediately,
-    // causing a double-delete
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (textField.text.length == 0) {
-            CLTokenView *tokenView = self.tokenViews.lastObject;
-            if (tokenView) {
-                [self selectTokenView:tokenView animated:YES];
-                [self.textField resignFirstResponder];
-            }
+    if (textField.text.length == 0) {
+        CLTokenView *tokenView = self.tokenViews.lastObject;
+        if (tokenView) {
+            [self selectTokenView:tokenView animated:YES];
+            [self.textField resignFirstResponder];
         }
-    });
+    }
 }
 
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -41,7 +41,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 - (void)commonInit
 {
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
-    self.textField.backgroundColor = [UIColor orangeColor];
+    self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
     self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
     self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "CLTokenInputView",
+    platforms: [
+        .iOS(.v11)
+    ],
+    products: [
+        .library(name: "CLTokenInputView", targets: ["CLTokenInputView"])
+    ],
+    targets: [
+        .target(
+            name: "CLTokenInputView",
+            path: "CLTokenInputView/CLTokenInputView",
+            publicHeadersPath: "./"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary

Fixes backspace handling that selected the previous token while the text field still contained one character. Token selection now runs only after the field becomes empty.

The branch also removes the blank row below an idle token field, recalculates height when editing starts or ends, adds Swift Package Manager support for iOS 11 and later, and expands the Xcode and Swift ignore rules.

## Checks

Backspace behavior works on iOS 9 and iOS 10.

## Known gap

- On iOS 8, backspace on an already empty field no longer selects the previous token. The project owner confirmed this gap in review.
