### PR TITLE
Remove constants and expose styling

### DIFF
--- a/CLTokenInputView.podspec
+++ b/CLTokenInputView.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "CLTokenInputView"
-  s.version      = "2.4.0"
+  s.version      = "2.5.0"
   s.summary      = "A replica of iOS's native contact bubbles UI."
 
   s.description  = <<-DESC

--- a/CLTokenInputView.xcodeproj/project.pbxproj
+++ b/CLTokenInputView.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		65B16BC218BC26C9003AA819 /* CLToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BC118BC26C9003AA819 /* CLToken.m */; };
 		65B16BC318BC26C9003AA819 /* CLToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BC118BC26C9003AA819 /* CLToken.m */; };
 		65E86F821C407E3A0029E724 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 65E86F811C407E3A0029E724 /* LaunchScreen.storyboard */; };
+		BAC0AB601E0075FD00DFE9C4 /* CLTokenInputView.podspec in Resources */ = {isa = PBXBuildFile; fileRef = BAC0AB5F1E0075FD00DFE9C4 /* CLTokenInputView.podspec */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		65B16BC018BC26C9003AA819 /* CLToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CLToken.h; path = CLTokenInputView/CLToken.h; sourceTree = "<group>"; };
 		65B16BC118BC26C9003AA819 /* CLToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CLToken.m; path = CLTokenInputView/CLToken.m; sourceTree = "<group>"; };
 		65E86F811C407E3A0029E724 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		BAC0AB5F1E0075FD00DFE9C4 /* CLTokenInputView.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CLTokenInputView.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				65B16B8318BC16F6003AA819 /* CLTokenInputView */,
+				BAC0AB5F1E0075FD00DFE9C4 /* CLTokenInputView.podspec */,
 				65B16B9C18BC16F7003AA819 /* CLTokenInputViewTests */,
 				65B16B7C18BC16F6003AA819 /* Frameworks */,
 				65B16B7B18BC16F6003AA819 /* Products */,
@@ -268,6 +271,7 @@
 				65B16B8818BC16F6003AA819 /* InfoPlist.strings in Resources */,
 				65E86F821C407E3A0029E724 /* LaunchScreen.storyboard in Resources */,
 				65B16B9018BC16F6003AA819 /* Images.xcassets in Resources */,
+				BAC0AB601E0075FD00DFE9C4 /* CLTokenInputView.podspec in Resources */,
 				65B16BBA18BC1826003AA819 /* CLTokenInputViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Color of optional */
 @property (strong, nonatomic, nullable) IBInspectable UIColor *fieldColor;
 @property (copy, nonatomic, nullable) IBInspectable NSString *placeholderText;
-@property (copy, nonatomic, nullable) IBInspectable NSAttributedString *attributedPlaceholderText;
+@property (copy, nonatomic, nullable) IBInspectable NSAttributedString *attributedPlaceholder;
 @property (strong, nonatomic, nullable) UIView *accessoryView;
 @property (assign, nonatomic) IBInspectable UIKeyboardType keyboardType;
 @property (assign, nonatomic) IBInspectable UITextAutocapitalizationType autocapitalizationType;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -90,6 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UIEdgeInsets fieldPadding;
 @property (assign, nonatomic) IBInspectable CGFloat standardRowHeight;
 @property (assign, nonatomic) IBInspectable CGFloat textFieldHSpace;
+@property (assign, nonatomic) IBInspectable CGFloat linePadding;
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -88,6 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UIKeyboardAppearance keyboardAppearance;
 @property (assign, nonatomic) IBInspectable UIEdgeInsets padding;
 @property (assign, nonatomic) IBInspectable UIEdgeInsets fieldPadding;
+@property (assign, nonatomic) IBInspectable UIEdgeInsets tokenPadding;
 @property (assign, nonatomic) IBInspectable CGFloat standardRowHeight;
 @property (assign, nonatomic) IBInspectable CGFloat textFieldHSpace;
 @property (assign, nonatomic) IBInspectable CGFloat linePadding;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -88,6 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UIKeyboardAppearance keyboardAppearance;
 @property (assign, nonatomic) IBInspectable UIEdgeInsets padding;
 @property (assign, nonatomic) IBInspectable UIEdgeInsets fieldPadding;
+@property (assign, nonatomic) IBInspectable CGFloat standardRowHeight;
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -91,6 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable CGFloat standardRowHeight;
 @property (assign, nonatomic) IBInspectable CGFloat textFieldHSpace;
 @property (assign, nonatomic) IBInspectable CGFloat linePadding;
+@property (assign, nonatomic) IBInspectable CGFloat minimumTextFieldWidth;
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -87,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UITextAutocorrectionType autocorrectionType;
 @property (assign, nonatomic) IBInspectable UIKeyboardAppearance keyboardAppearance;
 @property (assign, nonatomic) IBInspectable UIEdgeInsets padding;
+@property (assign, nonatomic) IBInspectable UIEdgeInsets fieldPadding;
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -89,6 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UIEdgeInsets padding;
 @property (assign, nonatomic) IBInspectable UIEdgeInsets fieldPadding;
 @property (assign, nonatomic) IBInspectable CGFloat standardRowHeight;
+@property (assign, nonatomic) IBInspectable CGFloat textFieldHSpace;
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -78,9 +78,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) UIView *fieldView;
 /** Option text which can be displayed before the first line (e.g. "To:") */
 @property (copy, nonatomic, nullable) IBInspectable NSString *fieldName;
+@property (copy, nonatomic, nullable) IBInspectable NSAttributedString *attributedFieldName;
 /** Color of optional */
 @property (strong, nonatomic, nullable) IBInspectable UIColor *fieldColor;
 @property (copy, nonatomic, nullable) IBInspectable NSString *placeholderText;
+@property (copy, nonatomic, nullable) IBInspectable NSAttributedString *attributedPlaceholderText;
 @property (strong, nonatomic, nullable) UIView *accessoryView;
 @property (assign, nonatomic) IBInspectable UIKeyboardType keyboardType;
 @property (assign, nonatomic) IBInspectable UITextAutocapitalizationType autocapitalizationType;
@@ -93,6 +95,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable CGFloat textFieldHSpace;
 @property (assign, nonatomic) IBInspectable CGFloat linePadding;
 @property (assign, nonatomic) IBInspectable CGFloat minimumTextFieldWidth;
+
+@property (copy, nonatomic) IBInspectable NSDictionary<NSString *,id> *defaultTextAttributes;
+@property (copy, nonatomic) IBInspectable NSDictionary<NSString *,id> *selectedTextAttributes;
+@property (copy, nonatomic) IBInspectable NSDictionary<NSString *,id> *placeholderTextAttributes;
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -86,6 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) IBInspectable UITextAutocapitalizationType autocapitalizationType;
 @property (assign, nonatomic) IBInspectable UITextAutocorrectionType autocorrectionType;
 @property (assign, nonatomic) IBInspectable UIKeyboardAppearance keyboardAppearance;
+@property (assign, nonatomic) IBInspectable UIEdgeInsets padding;
 /** 
  * Optional additional characters to trigger the tokenization process (and call the delegate
  * with `tokenInputView:tokenForText:`

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -15,7 +15,6 @@ static CGFloat const HSPACE = 0.0;
 static CGFloat const TEXT_FIELD_HSPACE = 4.0; // Note: Same as CLTokenView.PADDING_X
 static CGFloat const VSPACE = 4.0;
 static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
-static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
 
 @interface CLTokenInputView () <CLBackspaceDetectingTextFieldDelegate, CLTokenViewDelegate>
 
@@ -36,6 +35,7 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
 {
     self.padding = UIEdgeInsetsMake(10.0, 8.0, 10.0, 16.0);
     self.fieldPadding = UIEdgeInsetsMake(0.0, 4.0, 0.0, 4.0);
+    self.standardRowHeight = 25.0;
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
     self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -62,7 +62,6 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
     [self addSubview:self.fieldLabel];
     self.fieldLabel.hidden = YES;
 
-    self.intrinsicContentHeight = STANDARD_ROW_HEIGHT;
     [self repositionViews];
 }
 
@@ -183,20 +182,21 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
 
 - (void)repositionViews
 {
+    self.intrinsicContentHeight = self.standardRowHeight;
     CGRect bounds = self.bounds;
     CGFloat rightBoundary = CGRectGetWidth(bounds) - self.padding.right;
     CGFloat firstLineRightBoundary = rightBoundary;
 
     CGFloat curX = self.padding.left;
     CGFloat curY = self.padding.top;
-    CGFloat totalHeight = STANDARD_ROW_HEIGHT;
+    CGFloat totalHeight = self.standardRowHeight;
     BOOL isOnFirstLine = YES;
 
     // Position field view (if set)
     if (self.fieldView) {
         CGRect fieldViewRect = self.fieldView.frame;
         fieldViewRect.origin.x = curX + self.fieldPadding.left;
-        fieldViewRect.origin.y = curY + ((STANDARD_ROW_HEIGHT - CGRectGetHeight(fieldViewRect))/2.0);
+        fieldViewRect.origin.y = curY + ((self.standardRowHeight - CGRectGetHeight(fieldViewRect))/2.0);
         self.fieldView.frame = fieldViewRect;
 
         curX = CGRectGetMaxX(fieldViewRect) + self.fieldPadding.right;
@@ -208,7 +208,7 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
         CGRect fieldLabelRect = CGRectZero;
         fieldLabelRect.size = labelSize;
         fieldLabelRect.origin.x = curX + self.fieldPadding.left;
-        fieldLabelRect.origin.y = curY + ((STANDARD_ROW_HEIGHT-CGRectGetHeight(fieldLabelRect))/2.0);
+        fieldLabelRect.origin.y = curY + ((self.standardRowHeight-CGRectGetHeight(fieldLabelRect))/2.0);
         self.fieldLabel.frame = fieldLabelRect;
 
         curX = CGRectGetMaxX(fieldLabelRect) + self.fieldPadding.right;
@@ -233,14 +233,14 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
         if (curX + CGRectGetWidth(tokenRect) > tokenBoundary) {
             // Need a new line
             curX = self.padding.left;
-            curY += STANDARD_ROW_HEIGHT+VSPACE;
-            totalHeight += STANDARD_ROW_HEIGHT;
+            curY += self.standardRowHeight+VSPACE;
+            totalHeight += self.standardRowHeight;
             isOnFirstLine = NO;
         }
 
         tokenRect.origin.x = curX;
-        // Center our tokenView vertically within STANDARD_ROW_HEIGHT
-        tokenRect.origin.y = curY + ((STANDARD_ROW_HEIGHT-CGRectGetHeight(tokenRect))/2.0);
+        // Center our tokenView vertically within self.standardRowHeight
+        tokenRect.origin.y = curY + ((self.standardRowHeight-CGRectGetHeight(tokenRect))/2.0);
         tokenView.frame = tokenRect;
 
         curX = CGRectGetMaxX(tokenRect) + HSPACE;
@@ -257,8 +257,8 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
         // So leaving it set here, and marking the warning to ignore it
 #pragma unused(isOnFirstLine)
         curX = self.padding.left + TEXT_FIELD_HSPACE;
-        curY += STANDARD_ROW_HEIGHT+VSPACE;
-        totalHeight += STANDARD_ROW_HEIGHT;
+        curY += self.standardRowHeight+VSPACE;
+        totalHeight += self.standardRowHeight;
         // Adjust the width
         availableWidthForTextField = rightBoundary - curX;
     }
@@ -267,7 +267,7 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
     textFieldRect.origin.x = curX;
     textFieldRect.origin.y = curY + self.additionalTextFieldYOffset;
     textFieldRect.size.width = availableWidthForTextField;
-    textFieldRect.size.height = STANDARD_ROW_HEIGHT;
+    textFieldRect.size.height = self.standardRowHeight;
     self.textField.frame = textFieldRect;
 
     CGFloat oldContentHeight = self.intrinsicContentHeight;
@@ -505,6 +505,15 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
         return;
     }
     _fieldPadding = fieldPadding;
+    [self repositionViews];
+}
+
+- (void)setStandardRowHeight:(CGFloat)standardRowHeight
+{
+    if (_standardRowHeight == standardRowHeight) {
+        return;
+    }
+    _standardRowHeight = standardRowHeight;
     [self repositionViews];
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -112,6 +112,8 @@ static CGFloat const HSPACE = 0.0;
     [self.tokens addObject:token];
     CLTokenView *tokenView = [[CLTokenView alloc] initWithToken:token font:self.textField.font];
     tokenView.padding = _tokenPadding;
+    tokenView.defaultTextAttributes = self.defaultTextAttributes;
+    tokenView.selectedTextAttributes = self.selectedTextAttributes;
     if ([self respondsToSelector:@selector(tintColor)]) {
         tokenView.tintColor = self.tintColor;
     }
@@ -567,6 +569,39 @@ static CGFloat const HSPACE = 0.0;
     if (oldFieldName == nil || ![oldFieldName isEqualToString:fieldName]) {
         [self repositionViews];
     }
+}
+
+- (void)setAttributedFieldName:(NSAttributedString *)attributedFieldName
+{
+    if (_attributedFieldName == attributedFieldName) {
+        return;
+    }
+    NSAttributedString *oldAttributedFieldName = _attributedFieldName;
+    _attributedFieldName = attributedFieldName;
+    
+    self.fieldLabel.attributedText = _attributedFieldName;
+    [self.fieldLabel invalidateIntrinsicContentSize];
+    BOOL showField = (_attributedFieldName.string.length > 0);
+    self.fieldLabel.hidden = !showField;
+    if (showField && !self.fieldLabel.superview) {
+        [self addSubview:self.fieldLabel];
+    } else if (!showField && self.fieldLabel.superview) {
+        [self.fieldLabel removeFromSuperview];
+    }
+    
+    if (oldAttributedFieldName == nil || ![oldAttributedFieldName isEqualToAttributedString:attributedFieldName]) {
+        [self repositionViews];
+    }
+}
+
+- (void)setDefaultTextAttributes:(NSDictionary<NSString *,id> *)defaultTextAttributes
+{
+    self.textField.defaultTextAttributes = defaultTextAttributes;
+}
+
+- (void)setAttributedPlaceholderText:(NSAttributedString *)attributedPlaceholderText
+{
+    self.textField.attributedPlaceholder = attributedPlaceholderText;
 }
 
 - (void)setFieldColor:(UIColor *)fieldColor {

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -12,7 +12,6 @@
 #import "CLTokenView.h"
 
 static CGFloat const HSPACE = 0.0;
-static CGFloat const VSPACE = 4.0;
 static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
 
 @interface CLTokenInputView () <CLBackspaceDetectingTextFieldDelegate, CLTokenViewDelegate>
@@ -36,6 +35,7 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
     _fieldPadding = UIEdgeInsetsMake(0.0, 4.0, 0.0, 4.0);
     _standardRowHeight = 25.0;
     _textFieldHSpace = 4.0;
+    _linePadding = 4.0;
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
     self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -233,7 +233,7 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
         if (curX + CGRectGetWidth(tokenRect) > tokenBoundary) {
             // Need a new line
             curX = self.padding.left;
-            curY += self.standardRowHeight+VSPACE;
+            curY += self.standardRowHeight+self.linePadding;
             totalHeight += self.standardRowHeight;
             isOnFirstLine = NO;
         }
@@ -257,7 +257,7 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
         // So leaving it set here, and marking the warning to ignore it
 #pragma unused(isOnFirstLine)
         curX = self.padding.left + self.textFieldHSpace;
-        curY += self.standardRowHeight+VSPACE;
+        curY += self.standardRowHeight+self.linePadding;
         totalHeight += self.standardRowHeight;
         // Adjust the width
         availableWidthForTextField = rightBoundary - curX;
@@ -523,6 +523,15 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
         return;
     }
     _textFieldHSpace = textFieldHSpace;
+    [self repositionViews];
+}
+
+- (void)setLinePadding:(CGFloat)linePadding
+{
+    if (_linePadding == linePadding) {
+        return;
+    }
+    _linePadding = linePadding;
     [self repositionViews];
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -17,8 +17,6 @@ static CGFloat const VSPACE = 4.0;
 static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
 static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
 
-static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_X
-
 @interface CLTokenInputView () <CLBackspaceDetectingTextFieldDelegate, CLTokenViewDelegate>
 
 @property (strong, nonatomic) CL_GENERIC_MUTABLE_ARRAY(CLToken *) *tokens;
@@ -37,6 +35,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 - (void)commonInit
 {
     self.padding = UIEdgeInsetsMake(10.0, 8.0, 10.0, 16.0);
+    self.fieldPadding = UIEdgeInsetsMake(0.0, 4.0, 0.0, 4.0);
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
     self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -196,11 +195,11 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     // Position field view (if set)
     if (self.fieldView) {
         CGRect fieldViewRect = self.fieldView.frame;
-        fieldViewRect.origin.x = curX + FIELD_MARGIN_X;
+        fieldViewRect.origin.x = curX + self.fieldPadding.left;
         fieldViewRect.origin.y = curY + ((STANDARD_ROW_HEIGHT - CGRectGetHeight(fieldViewRect))/2.0);
         self.fieldView.frame = fieldViewRect;
 
-        curX = CGRectGetMaxX(fieldViewRect) + FIELD_MARGIN_X;
+        curX = CGRectGetMaxX(fieldViewRect) + self.fieldPadding.right;
     }
 
     // Position field label (if field name is set)
@@ -208,11 +207,11 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
         CGSize labelSize = self.fieldLabel.intrinsicContentSize;
         CGRect fieldLabelRect = CGRectZero;
         fieldLabelRect.size = labelSize;
-        fieldLabelRect.origin.x = curX + FIELD_MARGIN_X;
+        fieldLabelRect.origin.x = curX + self.fieldPadding.left;
         fieldLabelRect.origin.y = curY + ((STANDARD_ROW_HEIGHT-CGRectGetHeight(fieldLabelRect))/2.0);
         self.fieldLabel.frame = fieldLabelRect;
 
-        curX = CGRectGetMaxX(fieldLabelRect) + FIELD_MARGIN_X;
+        curX = CGRectGetMaxX(fieldLabelRect) + self.fieldPadding.right;
     }
 
     // Position accessory view (if set)

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -114,6 +114,8 @@ static CGFloat const HSPACE = 0.0;
     tokenView.padding = _tokenPadding;
     tokenView.defaultTextAttributes = self.defaultTextAttributes;
     tokenView.selectedTextAttributes = self.selectedTextAttributes;
+    tokenView.inputKeyboardAppearance = self.keyboardAppearance;
+    tokenView.inputKeyboardType = self.keyboardType;
     if ([self respondsToSelector:@selector(tintColor)]) {
         tokenView.tintColor = self.tintColor;
     }

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -35,7 +35,8 @@ static CGFloat const HSPACE = 0.0;
     _standardRowHeight = 25.0;
     _textFieldHSpace = 4.0;
     _linePadding = 4.0;
-    _minimumTextFieldWidth = 56.0
+    _minimumTextFieldWidth = 56.0;
+    _tokenPadding = UIEdgeInsetsMake(2.0, 4.0, 2.0, 4.0);
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
     self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -110,6 +111,7 @@ static CGFloat const HSPACE = 0.0;
 
     [self.tokens addObject:token];
     CLTokenView *tokenView = [[CLTokenView alloc] initWithToken:token font:self.textField.font];
+    tokenView.padding = _tokenPadding;
     if ([self respondsToSelector:@selector(tintColor)]) {
         tokenView.tintColor = self.tintColor;
     }

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -86,7 +86,7 @@ static CGFloat const HSPACE = 0.0;
 
 - (CGSize)intrinsicContentSize
 {
-    return CGSizeMake(UIViewNoIntrinsicMetric, MAX(45, self.intrinsicContentHeight));
+    return CGSizeMake(UIViewNoIntrinsicMetric, self.intrinsicContentHeight);
 }
 
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -599,9 +599,9 @@ static CGFloat const HSPACE = 0.0;
     self.textField.defaultTextAttributes = defaultTextAttributes;
 }
 
-- (void)setAttributedPlaceholderText:(NSAttributedString *)attributedPlaceholderText
+- (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder
 {
-    self.textField.attributedPlaceholder = attributedPlaceholderText;
+    self.textField.attributedPlaceholder = attributedPlaceholder;
 }
 
 - (void)setFieldColor:(UIColor *)fieldColor {

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -12,7 +12,6 @@
 #import "CLTokenView.h"
 
 static CGFloat const HSPACE = 0.0;
-static CGFloat const TEXT_FIELD_HSPACE = 4.0; // Note: Same as CLTokenView.PADDING_X
 static CGFloat const VSPACE = 4.0;
 static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
 
@@ -33,9 +32,10 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
 
 - (void)commonInit
 {
-    self.padding = UIEdgeInsetsMake(10.0, 8.0, 10.0, 16.0);
-    self.fieldPadding = UIEdgeInsetsMake(0.0, 4.0, 0.0, 4.0);
-    self.standardRowHeight = 25.0;
+    _padding = UIEdgeInsetsMake(10.0, 8.0, 10.0, 16.0);
+    _fieldPadding = UIEdgeInsetsMake(0.0, 4.0, 0.0, 4.0);
+    _standardRowHeight = 25.0;
+    _textFieldHSpace = 4.0;
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
     self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -247,7 +247,7 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
     }
 
     // Always indent textfield by a little bit
-    curX += TEXT_FIELD_HSPACE;
+    curX += self.textFieldHSpace;
     CGFloat textBoundary = isOnFirstLine ? firstLineRightBoundary : rightBoundary;
     CGFloat availableWidthForTextField = textBoundary - curX;
     if (availableWidthForTextField < MINIMUM_TEXTFIELD_WIDTH) {
@@ -256,7 +256,7 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
         // isOnFirstLine will be useful, and this calculation is important.
         // So leaving it set here, and marking the warning to ignore it
 #pragma unused(isOnFirstLine)
-        curX = self.padding.left + TEXT_FIELD_HSPACE;
+        curX = self.padding.left + self.textFieldHSpace;
         curY += self.standardRowHeight+VSPACE;
         totalHeight += self.standardRowHeight;
         // Adjust the width
@@ -514,6 +514,15 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
         return;
     }
     _standardRowHeight = standardRowHeight;
+    [self repositionViews];
+}
+
+- (void)setTextFieldHSpace:(CGFloat)textFieldHSpace
+{
+    if (_textFieldHSpace == textFieldHSpace) {
+        return;
+    }
+    _textFieldHSpace = textFieldHSpace;
     [self repositionViews];
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -499,7 +499,7 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
     [self repositionViews];
 }
 
-- (void)fieldPadding:(UIEdgeInsets)fieldPadding
+- (void)setFieldPadding:(UIEdgeInsets)fieldPadding
 {
     if (UIEdgeInsetsEqualToEdgeInsets(_fieldPadding, fieldPadding)) {
         return;

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -15,10 +15,6 @@ static CGFloat const HSPACE = 0.0;
 static CGFloat const TEXT_FIELD_HSPACE = 4.0; // Note: Same as CLTokenView.PADDING_X
 static CGFloat const VSPACE = 4.0;
 static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
-static CGFloat const PADDING_TOP = 10.0;
-static CGFloat const PADDING_BOTTOM = 10.0;
-static CGFloat const PADDING_LEFT = 8.0;
-static CGFloat const PADDING_RIGHT = 16.0;
 static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
 
 static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_X
@@ -40,6 +36,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 - (void)commonInit
 {
+    self.padding = UIEdgeInsetsMake(10.0, 8.0, 10.0, 16.0);
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
     self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -188,11 +185,11 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 - (void)repositionViews
 {
     CGRect bounds = self.bounds;
-    CGFloat rightBoundary = CGRectGetWidth(bounds) - PADDING_RIGHT;
+    CGFloat rightBoundary = CGRectGetWidth(bounds) - self.padding.right;
     CGFloat firstLineRightBoundary = rightBoundary;
 
-    CGFloat curX = PADDING_LEFT;
-    CGFloat curY = PADDING_TOP;
+    CGFloat curX = self.padding.left;
+    CGFloat curY = self.padding.top;
     CGFloat totalHeight = STANDARD_ROW_HEIGHT;
     BOOL isOnFirstLine = YES;
 
@@ -221,7 +218,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     // Position accessory view (if set)
     if (self.accessoryView) {
         CGRect accessoryRect = self.accessoryView.frame;
-        accessoryRect.origin.x = CGRectGetWidth(bounds) - PADDING_RIGHT - CGRectGetWidth(accessoryRect);
+        accessoryRect.origin.x = CGRectGetWidth(bounds) - self.padding.right - CGRectGetWidth(accessoryRect);
         accessoryRect.origin.y = curY;
         self.accessoryView.frame = accessoryRect;
 
@@ -236,7 +233,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
         CGFloat tokenBoundary = isOnFirstLine ? firstLineRightBoundary : rightBoundary;
         if (curX + CGRectGetWidth(tokenRect) > tokenBoundary) {
             // Need a new line
-            curX = PADDING_LEFT;
+            curX = self.padding.left;
             curY += STANDARD_ROW_HEIGHT+VSPACE;
             totalHeight += STANDARD_ROW_HEIGHT;
             isOnFirstLine = NO;
@@ -260,7 +257,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
         // isOnFirstLine will be useful, and this calculation is important.
         // So leaving it set here, and marking the warning to ignore it
 #pragma unused(isOnFirstLine)
-        curX = PADDING_LEFT + TEXT_FIELD_HSPACE;
+        curX = self.padding.left + TEXT_FIELD_HSPACE;
         curY += STANDARD_ROW_HEIGHT+VSPACE;
         totalHeight += STANDARD_ROW_HEIGHT;
         // Adjust the width
@@ -275,7 +272,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     self.textField.frame = textFieldRect;
 
     CGFloat oldContentHeight = self.intrinsicContentHeight;
-    self.intrinsicContentHeight = MAX(totalHeight, CGRectGetMaxY(textFieldRect)+PADDING_BOTTOM);
+    self.intrinsicContentHeight = MAX(totalHeight, CGRectGetMaxY(textFieldRect)+self.padding.bottom);
     [self invalidateIntrinsicContentSize];
 
     if (oldContentHeight != self.intrinsicContentHeight) {
@@ -405,8 +402,8 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 - (CGFloat)textFieldDisplayOffset
 {
-    // Essentially the textfield's y with PADDING_TOP
-    return CGRectGetMinY(self.textField.frame) - PADDING_TOP;
+    // Essentially the textfield's y with self.padding.top
+    return CGRectGetMinY(self.textField.frame) - self.padding.top;
 }
 
 
@@ -493,6 +490,15 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
 
 #pragma mark - (Optional Views)
+
+- (void)setPadding:(UIEdgeInsets)padding
+{
+    if (UIEdgeInsetsEqualToEdgeInsets(_padding, padding)) {
+        return;
+    }
+    _padding = padding;
+    [self repositionViews];
+}
 
 - (void)setFieldName:(NSString *)fieldName
 {

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -12,7 +12,6 @@
 #import "CLTokenView.h"
 
 static CGFloat const HSPACE = 0.0;
-static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
 
 @interface CLTokenInputView () <CLBackspaceDetectingTextFieldDelegate, CLTokenViewDelegate>
 
@@ -36,6 +35,7 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
     _standardRowHeight = 25.0;
     _textFieldHSpace = 4.0;
     _linePadding = 4.0;
+    _minimumTextFieldWidth = 56.0
     self.textField = [[CLBackspaceDetectingTextField alloc] initWithFrame:self.bounds];
     self.textField.backgroundColor = [UIColor clearColor];
     self.textField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -250,7 +250,7 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
     curX += self.textFieldHSpace;
     CGFloat textBoundary = isOnFirstLine ? firstLineRightBoundary : rightBoundary;
     CGFloat availableWidthForTextField = textBoundary - curX;
-    if (availableWidthForTextField < MINIMUM_TEXTFIELD_WIDTH) {
+    if (availableWidthForTextField < self.minimumTextFieldWidth) {
         isOnFirstLine = NO;
         // If in the future we add more UI elements below the tokens,
         // isOnFirstLine will be useful, and this calculation is important.
@@ -532,6 +532,15 @@ static CGFloat const MINIMUM_TEXTFIELD_WIDTH = 56.0;
         return;
     }
     _linePadding = linePadding;
+    [self repositionViews];
+}
+
+- (void) setMinimumTextFieldWidth:(CGFloat)minimumTextFieldWidth
+{
+    if (_minimumTextFieldWidth == minimumTextFieldWidth) {
+        return;
+    }
+    _minimumTextFieldWidth = minimumTextFieldWidth;
     [self repositionViews];
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -499,6 +499,15 @@ static CGFloat const STANDARD_ROW_HEIGHT = 25.0;
     [self repositionViews];
 }
 
+- (void)fieldPadding:(UIEdgeInsets)fieldPadding
+{
+    if (UIEdgeInsetsEqualToEdgeInsets(_fieldPadding, fieldPadding)) {
+        return;
+    }
+    _fieldPadding = fieldPadding;
+    [self repositionViews];
+}
+
 - (void)setFieldName:(NSString *)fieldName
 {
     if (_fieldName == fieldName) {

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic, nullable) NSObject <CLTokenViewDelegate> *delegate;
 @property (assign, nonatomic) BOOL selected;
 @property (assign, nonatomic) BOOL hideUnselectedComma;
+@property (assign, nonatomic) UIEdgeInsets padding;
 
 - (id)initWithToken:(CLToken *)token font:(nullable UIFont *)font;
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL selected;
 @property (assign, nonatomic) BOOL hideUnselectedComma;
 @property (assign, nonatomic) UIEdgeInsets padding;
+@property (copy, nonatomic) NSDictionary<NSString *,id> *defaultTextAttributes;
+@property (copy, nonatomic) NSDictionary<NSString *,id> *selectedTextAttributes;
 
 - (id)initWithToken:(CLToken *)token font:(nullable UIFont *)font;
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) UIEdgeInsets padding;
 @property (copy, nonatomic) NSDictionary<NSString *,id> *defaultTextAttributes;
 @property (copy, nonatomic) NSDictionary<NSString *,id> *selectedTextAttributes;
+@property (assign, nonatomic) UIKeyboardAppearance inputKeyboardAppearance;
+@property (assign, nonatomic) UIKeyboardType inputKeyboardType;
 
 - (id)initWithToken:(CLToken *)token font:(nullable UIFont *)font;
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.m
@@ -169,7 +169,23 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
 
 
 #pragma mark - Attributed Text
+- (void)setDefaultTextAttributes:(NSDictionary<NSString *,id> *)defaultTextAttributes
+{
+    if (![_defaultTextAttributes isEqualToDictionary:defaultTextAttributes]) {
+        _defaultTextAttributes = defaultTextAttributes;
+        [self updateLabelAttributedText];
+        [self setNeedsLayout];
+    }
+}
 
+- (void)setSelectedTextAttributes:(NSDictionary<NSString *,id> *)selectedTextAttributes
+{
+    if (![_selectedTextAttributes isEqualToDictionary:selectedTextAttributes]) {
+        _selectedTextAttributes = selectedTextAttributes;
+        [self updateLabelAttributedText];
+        [self setNeedsLayout];
+    }
+}
 
 - (void)updateLabelAttributedText
 {
@@ -179,10 +195,11 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
         format = UNSELECTED_LABEL_NO_COMMA_FORMAT;
     }
     NSString *labelString = [NSString stringWithFormat:format, self.displayText];
+    NSDictionary<NSString *, id>* attributes = self.defaultTextAttributes ?: @{NSFontAttributeName : self.label.font,
+                                                                           NSForegroundColorAttributeName : [UIColor lightGrayColor]};
     NSMutableAttributedString *attrString =
     [[NSMutableAttributedString alloc] initWithString:labelString
-                                           attributes:@{NSFontAttributeName : self.label.font,
-                                                        NSForegroundColorAttributeName : [UIColor lightGrayColor]}];
+                                           attributes:attributes];
     NSRange tintRange = [labelString rangeOfString:self.displayText];
     // Make the name part the system tint color
     UIColor *tintColor = self.selectedBackgroundView.backgroundColor;
@@ -192,6 +209,16 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
     [attrString setAttributes:@{NSForegroundColorAttributeName : tintColor}
                         range:tintRange];
     self.label.attributedText = attrString;
+    
+    NSMutableDictionary<NSString *, id>* selectedAttribtes;
+    if (self.selectedTextAttributes) {
+        selectedAttribtes = self.selectedTextAttributes;
+    } else {
+        selectedAttribtes = attributes;
+        selectedAttribtes[NSForegroundColorAttributeName] = [UIColor whiteColor];
+    }
+    self.selectedLabel.attributedText = [[NSAttributedString alloc] initWithString:self.displayText attributes:selectedAttribtes];
+    
 }
 
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.m
@@ -210,14 +210,14 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
                         range:tintRange];
     self.label.attributedText = attrString;
     
-    NSMutableDictionary<NSString *, id>* selectedAttribtes;
+    NSMutableDictionary<NSString *, id>* selectedAttributes;
     if (self.selectedTextAttributes) {
-        selectedAttribtes = self.selectedTextAttributes;
+        selectedAttributes = self.selectedTextAttributes;
     } else {
-        selectedAttribtes = attributes;
-        selectedAttribtes[NSForegroundColorAttributeName] = [UIColor whiteColor];
+        selectedAttributes = [[NSMutableDictionary alloc] initWithDictionary: attributes];
+        [selectedAttributes setObject:[UIColor whiteColor] forKey:NSForegroundColorAttributeName];
     }
-    self.selectedLabel.attributedText = [[NSAttributedString alloc] initWithString:self.displayText attributes:selectedAttribtes];
+    self.selectedLabel.attributedText = [[NSAttributedString alloc] initWithString:self.displayText attributes:selectedAttributes];
     
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.m
@@ -10,9 +10,6 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-static CGFloat const PADDING_X = 4.0;
-static CGFloat const PADDING_Y = 2.0;
-
 static NSString *const UNSELECTED_LABEL_FORMAT = @"%@,";
 static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
 
@@ -39,7 +36,7 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
         if ([self respondsToSelector:@selector(tintColor)]) {
             tintColor = self.tintColor;
         }
-        self.label = [[UILabel alloc] initWithFrame:CGRectMake(PADDING_X, PADDING_Y, 0, 0)];
+        self.label = [[UILabel alloc] initWithFrame:CGRectZero];
         if (font) {
             self.label.font = font;
         }
@@ -53,7 +50,7 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
         [self addSubview:self.selectedBackgroundView];
         self.selectedBackgroundView.hidden = YES;
 
-        self.selectedLabel = [[UILabel alloc] initWithFrame:CGRectMake(PADDING_X, PADDING_Y, 0, 0)];
+        self.selectedLabel = [[UILabel alloc] initWithFrame:CGRectZero];
         self.selectedLabel.font = self.label.font;
         self.selectedLabel.textColor = [UIColor whiteColor];
         self.selectedLabel.backgroundColor = [UIColor clearColor];
@@ -82,14 +79,14 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
 - (CGSize)intrinsicContentSize
 {
     CGSize labelIntrinsicSize = self.selectedLabel.intrinsicContentSize;
-    return CGSizeMake(labelIntrinsicSize.width+(2.0*PADDING_X), labelIntrinsicSize.height+(2.0*PADDING_Y));
+    return CGSizeMake(labelIntrinsicSize.width+self.padding.left+self.padding.right, labelIntrinsicSize.height+self.padding.top+self.padding.bottom);
 }
 
 - (CGSize)sizeThatFits:(CGSize)size
 {
-    CGSize fittingSize = CGSizeMake(size.width-(2.0*PADDING_X), size.height-(2.0*PADDING_Y));
+    CGSize fittingSize = CGSizeMake(size.width-(self.padding.left+self.padding.right), size.height-(self.padding.top+self.padding.bottom));
     CGSize labelSize = [self.selectedLabel sizeThatFits:fittingSize];
-    return CGSizeMake(labelSize.width+(2.0*PADDING_X), labelSize.height+(2.0*PADDING_Y));
+    return CGSizeMake(labelSize.width+(self.padding.left+self.padding.right), labelSize.height+(self.padding.top+self.padding.bottom));
 }
 
 
@@ -209,9 +206,9 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
     self.backgroundView.frame = bounds;
     self.selectedBackgroundView.frame = bounds;
 
-    CGRect labelFrame = CGRectInset(bounds, PADDING_X, PADDING_Y);
+    CGRect labelFrame = UIEdgeInsetsInsetRect(bounds, self.padding);
     self.selectedLabel.frame = labelFrame;
-    labelFrame.size.width += PADDING_X*2.0;
+    labelFrame.size.width += self.padding.left + self.padding.right;
     self.label.frame = labelFrame;
 }
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.m
@@ -276,6 +276,16 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
     return UITextAutocorrectionTypeNo;
 }
 
+- (UIKeyboardAppearance)keyboardAppearance
+{
+    return self.inputKeyboardAppearance;
+}
+
+- (UIKeyboardType)keyboardType
+{
+    return self.inputKeyboardType;
+}
+
 
 #pragma mark - First Responder (needed to capture keyboard)
 


### PR DESCRIPTION
I've exposed a number of properties on CLTokenInputView to enable better customization. 
All of the properties exposed were previous handled by constants.
These include:
`padding` (PADDING_*),`fieldPadding`, `standardRowHeight`, `textFieldHSpace`, `linePadding` (VSpace), `minimumTextFieldWidth`, `tokenPadding`

To allow for text styling without exposing the actual fields, there are now options for NSAttributedText attributes and NSAttributedStrings where needed.
`attributedFieldName`, `attributedPlaceholderText`, `defaultTextAttributes`, `selectedTextAttributes`, `placeholderTextAttributes`
