### PR TITLE
Add: Selecting previous token after deleting

### DIFF
--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -157,6 +157,11 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     if ([self.delegate respondsToSelector:@selector(tokenInputView:didRemoveToken:)]) {
         [self.delegate tokenInputView:self didRemoveToken:removedToken];
     }
+    if (self.tokenViews.count > 0) {
+        NSInteger prevIndex = (index - 1 < 0) ? self.tokenViews.count - 1 : index - 1;
+        tokenView = self.tokenViews[prevIndex];
+        [self selectTokenView:tokenView animated:YES];
+    }
     [self updatePlaceholderTextVisibility];
     [self repositionViews];
 }


### PR DESCRIPTION
Now cursor select previous(i.e. left, if it doesn't exist then select last) token after removing token istead of jumping to the end of text field. I think it is more user friendly.