### PR TITLE
TextField Access

### DIFF
--- a/CLTokenInputView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CLTokenInputView.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -109,6 +109,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)beginEditing;
 - (void)endEditing;
 
+- (BOOL)isTokenViewTextFieldFirstResponder;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.h
@@ -110,6 +110,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)endEditing;
 
 - (BOOL)isTokenViewTextFieldFirstResponder;
+- (BOOL)tokenViewTextFieldCanBecomeFirstResponder;
+- (BOOL)tokenViewTextFieldBecomeFirstResponder;
 
 @end
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -300,6 +300,13 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 }
 
 
+#pragma mark - Text Field Access
+
+- (BOOL)isTokenViewTextFieldFirstResponder
+{
+    return [self.textField isFirstResponder];
+}
+
 #pragma mark - CLBackspaceDetectingTextFieldDelegate
 
 - (void)textFieldDidDeleteBackwards:(UITextField *)textField
@@ -317,7 +324,6 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
         }
     });
 }
-
 
 #pragma mark - UITextFieldDelegate
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -127,10 +127,7 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     if ([self.delegate respondsToSelector:@selector(tokenInputView:didAddToken:)]) {
         [self.delegate tokenInputView:self didAddToken:token];
     }
-
-    // Clearing text programmatically doesn't call this automatically
-    [self onTextFieldDidChange:self.textField];
-
+    
     [self updatePlaceholderTextVisibility];
     [self repositionViews];
 }

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -307,6 +307,16 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
     return [self.textField isFirstResponder];
 }
 
+- (BOOL)tokenViewTextFieldCanBecomeFirstResponder
+{
+    return [self.textField canBecomeFirstResponder];
+}
+
+- (BOOL)tokenViewTextFieldBecomeFirstResponder
+{
+    return [self.textField becomeFirstResponder];
+}
+
 #pragma mark - CLBackspaceDetectingTextFieldDelegate
 
 - (void)textFieldDidDeleteBackwards:(UITextField *)textField


### PR DESCRIPTION
- Adds textFeild access methods for `CLTokenInputView` class.
```
- (BOOL)isTokenViewTextFieldFirstResponder;
- (BOOL)tokenViewTextFieldCanBecomeFirstResponder;
- (BOOL)tokenViewTextFieldBecomeFirstResponder;
```
- Remove `onTextFieldDidChange:` from `addToken:`.
> More on this in the commit.